### PR TITLE
Add fade-in animation for cards

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -100,7 +100,14 @@ nav {
     border-radius: 10px;
     padding: 1.5rem;
     box-shadow: 0 2px 10px rgba(6, 84, 70, 0.1);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, opacity 0.6s ease;
+}
+
+.card.fade-in {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .card:hover {


### PR DESCRIPTION
## Summary
- animate cards with `.fade-in` class
- ensure `initializeCardAnimations` uses the `.fade-in` class to trigger animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846bca7d490832ca6af249f7cdd05e5